### PR TITLE
feat: add ErrorLevel to logError

### DIFF
--- a/src/hooks/useApi/index.tsx
+++ b/src/hooks/useApi/index.tsx
@@ -12,7 +12,10 @@ export function useApi<T>({ key, fetchMethod, options }: Props) {
     key,
     async () => {
       const { data: fetchData } = await fetchMethod();
-      if (error) logError(error, `An error occurred when fetching ${key}`);
+      if (error)
+        logError(error, {
+          customMessage: `An error occurred when fetching ${key}`,
+        });
 
       return fetchData;
     },

--- a/src/hooks/useContractRequest/index.tsx
+++ b/src/hooks/useContractRequest/index.tsx
@@ -11,7 +11,10 @@ export function useContractRequest<T>({ key, fetchMethod, options }: Props) {
     key,
     async () => {
       const fetchData = await fetchMethod();
-      if (error) logError(error, `An error occurred when fetching ${key}`);
+      if (error)
+        logError(error, {
+          customMessage: `An error occurred when fetching ${key}`,
+        });
 
       return fetchData;
     },

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -31,7 +31,10 @@ export function logEvent(eventName: string, params?: EventParams): void {
     }
   } catch (error) {
     if (!(error instanceof EventNameTooLongError)) {
-      logError(error, "Error sending event to analytics", { params });
+      logError(error, {
+        customMessage: "Error sending event to analytics",
+        context: { params },
+      });
     }
   }
 }
@@ -42,7 +45,7 @@ export function setUserProperties(
   try {
     firebase.analytics().setUserProperties(properties);
   } catch (error) {
-    logError(error, "Error sending properties to analytics");
+    logError(error, { customMessage: "Error sending properties to analytics" });
   }
 }
 

--- a/src/services/crashReport/index.test.ts
+++ b/src/services/crashReport/index.test.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/react";
-import { logError } from ".";
+import { ErrorLevel, logError } from ".";
 
 jest.spyOn(Sentry, "setTags");
 jest.spyOn(Sentry, "captureException");
@@ -23,22 +23,25 @@ describe("#logError", () => {
   });
 
   it("expects to call captureException", () => {
-    logError(error, customMessage);
+    logError(error, { customMessage });
     const contexts = {
       contextParams: {},
     };
 
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, { contexts });
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      contexts,
+      level: ErrorLevel.Error,
+    });
   });
 
   it("expects not to call setContext", () => {
-    logError(error, customMessage);
+    logError(error, { customMessage });
     expect(Sentry.setContext).not.toHaveBeenCalled();
   });
 
   describe("when sending a customMessage", () => {
     it("expects to set a tag with that custom message", () => {
-      logError(error, customMessage);
+      logError(error, { customMessage });
       expect(Sentry.setTags).toHaveBeenCalledWith({
         errorMessage: error.message,
         customMessage,
@@ -49,11 +52,25 @@ describe("#logError", () => {
   describe("when sending a context", () => {
     it("expects to call captureException with the context", () => {
       const context = { message: "context" };
-      logError(error, customMessage, context);
+      logError(error, { customMessage, context });
       expect(Sentry.captureException).toHaveBeenCalledWith(error, {
         contexts: {
           contextParams: context,
         },
+        level: ErrorLevel.Error,
+      });
+    });
+  });
+
+  describe("when sending a error level", () => {
+    it("expects to call captureException with the error level", () => {
+      const contexts = {
+        contextParams: {},
+      };
+      logError(error, { level: ErrorLevel.Fatal });
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        level: ErrorLevel.Fatal,
+        contexts,
       });
     });
   });

--- a/src/services/crashReport/index.ts
+++ b/src/services/crashReport/index.ts
@@ -1,9 +1,17 @@
 import * as Sentry from "@sentry/react";
+import { Severity } from "@sentry/react";
+
+type LogErrorProps = {
+  customMessage?: string;
+  context?: Record<string, unknown>;
+  level?: Severity;
+};
+
+export const ErrorLevel = Severity;
 
 export function logError(
   error: any,
-  customMessage?: string,
-  context: Record<string, unknown> = {},
+  { customMessage, context = {}, level = ErrorLevel.Error }: LogErrorProps = {},
 ): void {
   if (process.env.NODE_ENV !== "production") {
     return;
@@ -15,6 +23,7 @@ export function logError(
   });
 
   Sentry.captureException(error, {
+    level,
     contexts: { contextParams: context },
   });
 }


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Add error level to logError

Now we can use `logError` with a level param, and if it is sent as `fatal` sentry will automatically send a notification on discord

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
