### PR TITLE
refactor: changes toast timeout to 10 seconds

### DIFF
--- a/src/hooks/useToast/index.ts
+++ b/src/hooks/useToast/index.ts
@@ -10,11 +10,12 @@ type Props = {
   message: string;
   type?: "success" | "error";
   link?: string;
+  timeout?: number;
 };
 
 const useToast = () => {
   const { dispatch } = useContext(ToastContext);
-  function toast({ type = "success", message, link }: Props) {
+  function toast({ type = "success", message, link, timeout = 10000 }: Props) {
     const id = Math.random();
     dispatch({
       type: ADD_NOTIFICATION,
@@ -33,7 +34,7 @@ const useToast = () => {
         type: DELETE_NOTIFICATION,
         payload: id,
       });
-    }, 4000);
+    }, timeout);
   }
 
   return toast;


### PR DESCRIPTION
Changes toast timeout to 10 seconds and makes it an optional prop that can be passed when calling the function

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
