### PR TITLE
ui adjustment - consistent font size for titles in fund pages

### DIFF
--- a/src/pages/promoters/SupportFundPage/styles.ts
+++ b/src/pages/promoters/SupportFundPage/styles.ts
@@ -21,7 +21,7 @@ export const Title = styled.h1`
 
   ${({ theme }) => css`
     @media (min-width: ${theme.breakpoints.pad}) {
-      font-size: 24px;
+      font-size: 36px;
     }
   `}
 `;


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
For screens above 600px width
Changed font size from **24px to 36px** to match with other fund pages' title

## Does this pull request close any open issues?
- closes #255

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
