### PR TITLE
Fix: Adjust text align to left on CardCenterImageButton

### DIFF
--- a/src/components/moleculars/cards/CardCenterImageButton/styles.ts
+++ b/src/components/moleculars/cards/CardCenterImageButton/styles.ts
@@ -44,7 +44,7 @@ export const Text = styled.h3`
   ${({ theme }) => css`
     color: ${theme.colors.ribonBlack};
     font-weight: 700;
-    text-align: center;
+    align-self: flex-start;
     margin-bottom: 8px;
   `}
 `;


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
This PR changes the text align from center to left on `CardCenterImageButton`

# Necessary changes
- No necessary  changes

## Does this pull request close any open issues?
closes: #253

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How it's looking now
![image](https://user-images.githubusercontent.com/58452911/177800876-b0ec389f-9163-4500-95db-09a4ed9bd816.png)


