### PR TITLE
fix: remove double logo if it is Ribon`s integration

### DIFF
--- a/src/components/atomics/sections/Header/index.tsx
+++ b/src/components/atomics/sections/Header/index.tsx
@@ -26,8 +26,12 @@ function Header({
         ) : (
           <>
             <S.Logo src={Logo} alt="logo" />
-            <S.Divider>|</S.Divider>
-            <S.Logo src={sideLogo} alt="side-logo" />
+            {sideLogo && (
+              <>
+                <S.Divider>|</S.Divider>
+                <S.Logo src={sideLogo} alt="side-logo" />{" "}
+              </>
+            )}
           </>
         )}
       </S.LeftContainer>

--- a/src/hooks/useIntegrationId/index.tsx
+++ b/src/hooks/useIntegrationId/index.tsx
@@ -1,9 +1,9 @@
+import { RIBON_COMPANY_ID } from "utils/constants";
 import useQueryParams from "../useQueryParams";
 
 export function useIntegrationId() {
   const queryParams = useQueryParams();
-  const RIBON_ID = process.env.REACT_APP_RIBON_COMPANY_ID;
-  const INTEGRATION_ID = queryParams.get("integration_id") || RIBON_ID;
+  const INTEGRATION_ID = queryParams.get("integration_id") || RIBON_COMPANY_ID;
   if (!INTEGRATION_ID) return null;
 
   return parseInt(INTEGRATION_ID, 10);

--- a/src/layouts/LayoutHeader/index.tsx
+++ b/src/layouts/LayoutHeader/index.tsx
@@ -14,6 +14,7 @@ import { useIntegrationId } from "hooks/useIntegrationId";
 import useNavigation from "hooks/useNavigation";
 import { useBlockedDonationModal } from "hooks/modalHooks/useBlockedDonationModal";
 import { useDonationTicketModal } from "hooks/modalHooks/useDonationTicketModal";
+import { RIBON_COMPANY_ID } from "utils/constants";
 import ChangeLanguageItem from "./ChangeLanguageItem";
 import LogoutItem from "./LogoutItem";
 import * as S from "./styles";
@@ -58,6 +59,12 @@ function LayoutHeader({
     }
   }
 
+  function renderSideLogo() {
+    if (integrationId?.toString() === RIBON_COMPANY_ID) return undefined;
+
+    return integration?.logo;
+  }
+
   return (
     <S.Container>
       <ModalBlank
@@ -87,7 +94,7 @@ function LayoutHeader({
       <Header
         hasBackButton={hasBackButton}
         onBackButtonClick={navigateBack}
-        sideLogo={integration?.logo}
+        sideLogo={renderSideLogo()}
         rightComponent={
           <S.ContainerRight>
             {rightComponent}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const RIBON_COMPANY_ID = process.env.REACT_APP_RIBON_COMPANY_ID;


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Remove Ribon's logo when it is the Ribon integration

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
