### PR TITLE
Chore/allow UUID to fetch integrations

### DIFF
--- a/src/hooks/apiHooks/useIntegration/index.ts
+++ b/src/hooks/apiHooks/useIntegration/index.ts
@@ -2,7 +2,7 @@ import { useApi } from "hooks/useApi";
 import integrationsApi from "services/api/integrationsApi";
 import Integration from "types/entities/Integration";
 
-function useIntegration(integrationId: number | null | undefined) {
+function useIntegration(integrationId: number | string | null | undefined) {
   if (!integrationId)
     return {
       integration: {} as Integration,

--- a/src/hooks/useIntegrationId/index.tsx
+++ b/src/hooks/useIntegrationId/index.tsx
@@ -1,3 +1,4 @@
+import { isValidUuid } from "lib/validators";
 import { RIBON_COMPANY_ID } from "utils/constants";
 import useQueryParams from "../useQueryParams";
 
@@ -5,6 +6,7 @@ export function useIntegrationId() {
   const queryParams = useQueryParams();
   const INTEGRATION_ID = queryParams.get("integration_id") || RIBON_COMPANY_ID;
   if (!INTEGRATION_ID) return null;
+  if (isValidUuid(INTEGRATION_ID)) return String(INTEGRATION_ID);
 
   return parseInt(INTEGRATION_ID, 10);
 }

--- a/src/lib/validators/index.test.tsx
+++ b/src/lib/validators/index.test.tsx
@@ -1,4 +1,4 @@
-import { isValidEmail } from ".";
+import { isValidEmail, isValidUuid } from ".";
 
 describe("should check email", () => {
   it("expects to return false", () => {
@@ -9,3 +9,14 @@ describe("should check email", () => {
     expect(isValidEmail("foo@bar.com")).toBe(true);
   });
 });
+
+describe("should check uuid", () => {
+  it("expects to return false", () => {
+    expect(isValidUuid("invalid_uuid")).toBe(false);
+  });
+
+  it("expects to return true", () => {
+    expect(isValidUuid("c5c680cf-3a7a-4ea1-ade6-e5eb77e83c88")).toBe(true);
+  });
+});
+

--- a/src/lib/validators/index.test.tsx
+++ b/src/lib/validators/index.test.tsx
@@ -19,4 +19,3 @@ describe("should check uuid", () => {
     expect(isValidUuid("c5c680cf-3a7a-4ea1-ade6-e5eb77e83c88")).toBe(true);
   });
 });
-

--- a/src/lib/validators/index.tsx
+++ b/src/lib/validators/index.tsx
@@ -29,3 +29,10 @@ export function validatePicture(pictureUrl: string, defaultIcon: string) {
 
   return pictureUrl;
 }
+
+export function isValidUuid(uuid: string) {
+  const pattern = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+
+
+  return pattern.test(uuid);
+}

--- a/src/lib/validators/index.tsx
+++ b/src/lib/validators/index.tsx
@@ -31,8 +31,8 @@ export function validatePicture(pictureUrl: string, defaultIcon: string) {
 }
 
 export function isValidUuid(uuid: string) {
-  const pattern = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
-
+  const pattern =
+    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
 
   return pattern.test(uuid);
 }

--- a/src/pages/donations/CausesPage/index.tsx
+++ b/src/pages/donations/CausesPage/index.tsx
@@ -104,8 +104,8 @@ function CausesPage(): JSX.Element {
         if (!signedIn) {
           logEvent("authDonationDialButton_click");
           const user = await findOrCreateUser(email);
-          if (integrationId) {
-            createSource(user.id, integrationId);
+          if (integration) {
+            createSource(user.id, integration.id);
           }
           setCurrentUser(user);
         }

--- a/src/services/api/integrationsApi/index.test.ts
+++ b/src/services/api/integrationsApi/index.test.ts
@@ -7,10 +7,17 @@ describe("integrationsApi", () => {
       api.get = jest.fn();
     });
 
-    it("expects to send a get request with the correct info: url, params and headers", () => {
+    it("expects to send a get request with the correct info: url, id and headers", () => {
       integrationsApi.getIntegration(1);
 
       expect(api.get).toHaveBeenCalledWith("/api/v1/integrations/1");
+    });
+
+    it("expects to send a get request with the correct info: url, uuid and headers", () => {
+      const uuid = "64a3a5af-c249-4815-b89a-43986efb0de7"
+      integrationsApi.getIntegration(uuid);
+
+      expect(api.get).toHaveBeenCalledWith(`/api/v1/integrations/${uuid}`);
     });
   });
 });

--- a/src/services/api/integrationsApi/index.ts
+++ b/src/services/api/integrationsApi/index.ts
@@ -3,7 +3,7 @@ import Integration from "types/entities/Integration";
 import { apiGet } from "..";
 
 const integrationsApi = {
-  getIntegration: (id: number): Promise<AxiosResponse<Integration>> =>
+  getIntegration: (id: number | string): Promise<AxiosResponse<Integration>> =>
     apiGet(`integrations/${id}`),
 };
 


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- We are now able to fetch existing integrations by their UUID. As a fallback, the numeric id still available for a while.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
