### PR TITLE
test: add side logo img test to header

### DIFF
--- a/src/components/atomics/sections/Header/index.test.tsx
+++ b/src/components/atomics/sections/Header/index.test.tsx
@@ -40,4 +40,15 @@ describe("Header", () => {
       expect(mockFn).toHaveBeenCalled();
     });
   });
+
+  describe("when it has a side logo", () => {
+    beforeEach(() => {
+      const sidelogo = "src/assets/images/heart.svg"
+      renderComponent(<Header sideLogo={sidelogo} />);
+    });
+
+    it("shows the side logo image", () => {
+      expectImageToBeInTheDocument("side-logo")
+    })
+  });
 });


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- Added a test for the side logo on the Header Component to secure 100% of test coverage.

## Does this pull request close any open issues?
- Closes #463 

## Type of change

- [x] Tests

![image](https://user-images.githubusercontent.com/80076878/187520400-1ddd8a3b-ac27-43f5-a08f-7fe623bb5155.png)

