### PR TITLE
refactor: changes expiration date mask

### DIFF
--- a/src/components/atomics/inputs/InputText/index.tsx
+++ b/src/components/atomics/inputs/InputText/index.tsx
@@ -10,6 +10,7 @@ export type Props = {
   minLength?: number;
   required?: boolean;
   disabled?: boolean;
+  autofill?: string;
   onChange?: (value: any) => void;
 };
 
@@ -23,6 +24,7 @@ function InputText({
   maxLength,
   minLength,
   disabled,
+  autofill,
 }: Props): JSX.Element {
   return (
     <S.Container>
@@ -37,6 +39,7 @@ function InputText({
         minLength={minLength}
         onChange={onChange}
         disabled={disabled}
+        autoComplete={autofill}
       />
     </S.Container>
   );

--- a/src/contexts/cardPaymentInformationContext/index.tsx
+++ b/src/contexts/cardPaymentInformationContext/index.tsx
@@ -125,12 +125,13 @@ function CardPaymentInformationProvider({ children }: Props) {
         number: number.replace(/\D/g, ""),
         name,
         expirationMonth: expiration[0],
-        expirationYear: expiration[1],
+        expirationYear: expiration[1].slice(-2),
         cvv,
       },
     };
 
     try {
+      console.log(paymentInformation);
       await creditCardPaymentApi.postCreditCardPayment(paymentInformation);
 
       show();

--- a/src/contexts/cardPaymentInformationContext/index.tsx
+++ b/src/contexts/cardPaymentInformationContext/index.tsx
@@ -131,7 +131,6 @@ function CardPaymentInformationProvider({ children }: Props) {
     };
 
     try {
-      console.log(paymentInformation);
       await creditCardPaymentApi.postCreditCardPayment(paymentInformation);
 
       show();

--- a/src/lib/maskToExpirationDate/index.test.tsx
+++ b/src/lib/maskToExpirationDate/index.test.tsx
@@ -2,10 +2,10 @@ import { maskToExpirationDate } from ".";
 
 describe("should format month and year", () => {
   it("expects to return formatted month and year", () => {
-    expect(maskToExpirationDate("1107")).toBe("11/07");
+    expect(maskToExpirationDate("112007")).toBe("11/2007");
   });
 
   it("expects to return formatted with 4 numbers", () => {
-    expect(maskToExpirationDate("11233")).toBe("11/23");
+    expect(maskToExpirationDate("112033")).toBe("11/2033");
   });
 });

--- a/src/lib/maskToExpirationDate/index.ts
+++ b/src/lib/maskToExpirationDate/index.ts
@@ -1,7 +1,9 @@
-export const maskToExpirationDate = (date: string) =>
-  date
-    .replace(/[^0-9]/g, "")
-    .replace(/^([2-9])$/g, "0$1")
-    .replace(/^(1{1})([3-9]{1})$/g, "0$1/$2")
-    .replace(/^0{1,}/g, "0")
-    .replace(/^([0-1]{1}[0-9]{1})([0-9]{1,2}).*/g, "$1/$2");
+export const maskToExpirationDate = (date: string) => {
+  const v = date.replace(/\D/g, "").slice(0, 10);
+  if (v.length >= 5) {
+    return `${v.slice(0, 2)}/${v.slice(2, 6)}`;
+  } else if (v.length >= 3) {
+    return `${v.slice(0, 2)}/${v.slice(2)}`;
+  }
+  return v;
+};

--- a/src/pages/promoters/SupportTreasurePage/CardSection/PaymentInformationPage/PaymentInformationSection/index.tsx
+++ b/src/pages/promoters/SupportTreasurePage/CardSection/PaymentInformationPage/PaymentInformationSection/index.tsx
@@ -82,9 +82,11 @@ function PaymentInformationSection() {
       <S.Half>
         <InputText
           name="expirationDate"
+          autofill="cc-exp"
           value={expirationDate}
           placeholder={t("cardDueDate")}
           onChange={maskExpiration}
+          maxLength={7}
           required
         />
         <InputText


### PR DESCRIPTION
# Description
- Problem this PR closes: when users used browser autocomplete, card expiration date input  only took the year's first two digits (e.g.: 08/2031 => 08/20)
- Solution: mask for expiration date was changed to accept mm/yyyy format as well as mm/yy, but in either case the information sent was in mm and yy

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
