### PR TITLE
fix: 'proceed to checkout' button is behind top bar

### DIFF
--- a/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
+++ b/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
@@ -41,6 +41,8 @@ export const ButtonContainer = styled.div`
   align-self: end;
   background-color: white;
   box-shadow: 0 -4px 4px ${({ theme }) => theme.colors.lightShadow};
+  z-index: 9999;
+  
 
   @media (min-width: ${({ theme }) => theme.breakpoints.pad}) {
     height: 60px;

--- a/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
+++ b/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
@@ -43,8 +43,6 @@ export const ButtonContainer = styled.div`
   background-color: white;
   box-shadow: 0 -4px 4px ${({ theme }) => theme.colors.lightShadow};
 
-  
-
   @media (min-width: ${({ theme }) => theme.breakpoints.pad}) {
     height: 60px;
     padding: 0;

--- a/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
+++ b/src/pages/promoters/SupportTreasurePage/CardSection/styles.ts
@@ -36,12 +36,13 @@ export const ButtonContainer = styled.div`
   right: 0;
   bottom: 0;
   left: 0;
+  z-index: 9999;
   display: flex;
   align-items: center;
   align-self: end;
   background-color: white;
   box-shadow: 0 -4px 4px ${({ theme }) => theme.colors.lightShadow};
-  z-index: 9999;
+
   
 
   @media (min-width: ${({ theme }) => theme.breakpoints.pad}) {


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- In the support treasure section, when we are on mobile, the 'Proceed to checkout' button is not showing, because it's behind the top bar.
![image](https://user-images.githubusercontent.com/24739860/192549961-829fbfe6-616d-49bd-8f38-799592f1658a.png)

# Necessary changes
- Change z-index of button on mobile
![image](https://user-images.githubusercontent.com/24739860/192550306-d07442c3-b708-41a7-8404-7d5e8513136a.png)

