### PR TITLE
Feature/dapp 569

### DIFF
--- a/src/components/moleculars/modals/ModalDoubleImage/index.tsx
+++ b/src/components/moleculars/modals/ModalDoubleImage/index.tsx
@@ -63,16 +63,26 @@ function ModalDoubleImage({
   customStyles,
 }: Props): JSX.Element {
   function renderDoubleImage() {
-    if (leftImage && rightImage) {
-      return (
-        <S.ImageContainer>
-          <S.LeftImage src={leftImage} alt={leftImageAlt} />
-          <S.RightImage src={rightImage} alt={rightImageAlt} />
-        </S.ImageContainer>
-      );
-    }
+    const hasDoubleImage = Boolean(leftImage && rightImage);
 
-    return null;
+    return (
+      <S.ImageContainer>
+        {leftImage && (
+          <S.LeftImage
+            src={leftImage}
+            alt={leftImageAlt}
+            hasAdjacent={hasDoubleImage}
+          />
+        )}
+        {rightImage && (
+          <S.RightImage
+            src={rightImage}
+            alt={rightImageAlt}
+            hasAdjacent={hasDoubleImage}
+          />
+        )}
+      </S.ImageContainer>
+    );
   }
 
   return (

--- a/src/components/moleculars/modals/ModalDoubleImage/styles.ts
+++ b/src/components/moleculars/modals/ModalDoubleImage/styles.ts
@@ -24,6 +24,10 @@ type TitleProps = {
   color?: string;
 };
 
+type DoubleImageProps = {
+  hasAdjacent?: boolean;
+};
+
 export const Title = styled.h3<TitleProps>`
   margin-bottom: 8px;
   text-align: center;
@@ -55,14 +59,15 @@ export const ImageContainer = styled.div`
   display: block;
   align-items: center;
   justify-content: center;
+  text-align: center;
 `;
 
-export const LeftImage = styled.img`
+export const LeftImage = styled.img<DoubleImageProps>`
   width: 90px;
   height: 90px;
   border: solid 2px ${({ theme }) => theme.colors.defaultShadow};
   border-radius: 50%;
-  position: absolute;
+  position: ${({ hasAdjacent }) => (hasAdjacent ? "absolute" : "relative")};
   left: 0;
   z-index: ${({ theme }) => theme.zindex.above};
   object-fit: contain;
@@ -70,12 +75,12 @@ export const LeftImage = styled.img`
   filter: drop-shadow(0 20px 40px ${({ theme }) => theme.colors.defaultShadow});
 `;
 
-export const RightImage = styled.img`
+export const RightImage = styled.img<DoubleImageProps>`
   width: 90px;
   height: 90px;
   border: solid 2px ${({ theme }) => theme.colors.defaultShadow};
   border-radius: 50%;
-  position: absolute;
+  position: ${({ hasAdjacent }) => (hasAdjacent ? "absolute" : "relative")};
   right: 0;
   object-fit: cover;
   filter: drop-shadow(0 20px 40px ${({ theme }) => theme.colors.defaultShadow});

--- a/src/hooks/modalHooks/useDonationTicketModal/index.tsx
+++ b/src/hooks/modalHooks/useDonationTicketModal/index.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import { useAnimationReceiveTicketModal } from "hooks/modalHooks/useAnimationReceiveTicketModal";
 import { MODAL_TYPES } from "contexts/modalContext/helpers";
 import { useEffect } from "react";
-import Ticket from "assets/images/ticket.svg";
 import Integration from "types/entities/Integration";
 import { RIBON_COMPANY_ID } from "utils/constants";
 import RibonIcon from "assets/icons/logo-background-icon.svg";
@@ -18,6 +17,8 @@ export function useDonationTicketModal(
 
   const { showAnimationReceiveTicketModal } = useAnimationReceiveTicketModal();
 
+  const isRibonIntegration = integration?.id === parseInt(RIBON_COMPANY_ID, 10);
+
   const modalDoubleImageProps = {
     title: t("donationWithIntegrationModalTitle"),
     body: t("donationWithIntegrationModalSubtitle"),
@@ -26,28 +27,13 @@ export function useDonationTicketModal(
       showAnimationReceiveTicketModal();
     },
     onClose: () => showAnimationReceiveTicketModal(),
-    leftImage: integration?.logo,
+    leftImage: !isRibonIntegration ? integration?.logo : null,
     rightImage: RibonIcon,
   };
 
-  const modalIconProps = {
-    title: t("donationModalTitle"),
-    primaryButtonText: t("donationModalButtonText"),
-    primaryButtonCallback: () => {
-      showAnimationReceiveTicketModal();
-    },
-    onClose: () => showAnimationReceiveTicketModal(),
-    icon: Ticket,
-  };
-
-  const isNotRibonIntegration =
-    integration?.id !== parseInt(RIBON_COMPANY_ID, 10);
-
   const { show, hide } = useModal({
-    type: isNotRibonIntegration
-      ? MODAL_TYPES.MODAL_DOUBLE_IMAGE
-      : MODAL_TYPES.MODAL_ICON,
-    props: isNotRibonIntegration ? modalDoubleImageProps : modalIconProps,
+    type: MODAL_TYPES.MODAL_DOUBLE_IMAGE,
+    props: modalDoubleImageProps,
   });
 
   const showDonationTicketModal = () => {


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
 The integration modal needs to show just one logo (the ribon's one) in some cases:

- When the integration doesn't have logo
- When the integration is RIbon
- When we don't have integration configured

1. When it has an Integration with logo
![image](https://user-images.githubusercontent.com/24739860/195658958-9050f9e2-cc85-4f69-8511-40c8682844a9.png)

2. When integration is Ribon
![image](https://user-images.githubusercontent.com/24739860/195659058-6f91c8a9-f1cc-4065-9c3b-ad7a399ac9f6.png)

3. When integration doesn't have a logo
![image](https://user-images.githubusercontent.com/24739860/195659415-e7d656a5-2a2c-4349-ad97-026af2334033.png)



## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
