### PR TITLE
TECH-102: show refunded person payments with different style

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -110,7 +110,8 @@
         "transactionSuccessText": "Transaction successful",
         "transactionFailedText": "Transaction failed",
         "linkMessageToast": "Learn more",
-        "cardDonationText": "Given by card"
+        "cardDonationText": "Given by card",
+        "refunded": "Refunded"
       },
       "modalOnboarding": {
         "title": "Ribon’s Donation Treasure",

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -110,7 +110,8 @@
         "transactionSuccessText": "Transação processada",
         "transactionFailedText": "Falha ao processar transação",
         "linkMessageToast": "Saiba mais",
-        "cardDonationText": "Contribuição por cartão"
+        "cardDonationText": "Contribuição por cartão",
+        "refunded": "Estornada"
       },
       "modalOnboarding": {
         "title": "Tesouro de Doação da Ribon",

--- a/src/components/moleculars/cards/CardDoubleTextDividerButton/index.tsx
+++ b/src/components/moleculars/cards/CardDoubleTextDividerButton/index.tsx
@@ -12,6 +12,7 @@ export type Props = {
   link?: string;
   processing?: boolean;
   processingText?: string;
+  refunded?: boolean;
 };
 
 const { colors } = theme;
@@ -26,13 +27,14 @@ function CardDoubleTextDividerButton({
   link,
   processing = false,
   processingText,
+  refunded = false,
 }: Props): JSX.Element {
   return (
     <S.Container>
       <S.FirstText>{firstText}</S.FirstText>
-      <S.MainContent processing={processing}>
+      <S.MainContent processing={processing} refunded={refunded}>
         {mainText}{" "}
-        <S.RightMainContent processing={processing}>
+        <S.RightMainContent refunded={refunded} processing={processing}>
           {rightComplementText}
         </S.RightMainContent>
       </S.MainContent>
@@ -43,7 +45,7 @@ function CardDoubleTextDividerButton({
           {processingText}
         </S.SpinnerSection>
       ) : (
-        <S.LinkSection href={link}>
+        <S.LinkSection refunded={refunded} href={link}>
           {buttonText} <S.Image src={rightComponentButton} />
         </S.LinkSection>
       )}

--- a/src/components/moleculars/cards/CardDoubleTextDividerButton/styles.ts
+++ b/src/components/moleculars/cards/CardDoubleTextDividerButton/styles.ts
@@ -22,24 +22,39 @@ export const FirstText = styled.p`
 
 export const MainContent = styled.h3<{
   processing?: boolean;
+  refunded?: boolean;
 }>`
   ${defaultTitleLarge}
   color: ${(props) =>
-    props.processing ? props.theme.colors.gray30 : props.theme.colors.green30};
+    // eslint-disable-next-line no-nested-ternary
+    props.processing
+      ? props.theme.colors.gray30
+      : props.refunded
+      ? props.theme.colors.gray20
+      : props.theme.colors.green30};
 `;
 
 export const RightMainContent = styled.span<{
   processing?: boolean;
+  refunded?: boolean;
 }>`
   color: ${(props) =>
-    props.processing ? props.theme.colors.gray30 : props.theme.colors.green30};
+    // eslint-disable-next-line no-nested-ternary
+    props.processing
+      ? props.theme.colors.gray30
+      : props.refunded
+      ? props.theme.colors.gray20
+      : props.theme.colors.green30};
 `;
 
-export const LinkSection = styled.a`
+export const LinkSection = styled.a<{
+  refunded?: boolean;
+}>`
   display: flex;
   justify-content: space-between;
   text-decoration: none;
-  color: ${({ theme }) => theme.colors.gray40};
+  color: ${(props) =>
+    props.refunded ? props.theme.colors.gray20 : props.theme.colors.gray40};
 `;
 
 export const SpinnerSection = styled.a`

--- a/src/pages/promoters/TreasurePage/GivingsSection/PromoterGivingsSection/index.tsx
+++ b/src/pages/promoters/TreasurePage/GivingsSection/PromoterGivingsSection/index.tsx
@@ -212,7 +212,10 @@ function GivingsSection(): JSX.Element {
           firstText={paidDate(item.paidDate)}
           mainText={item.cryptoAmount}
           rightComplementText={coin}
-          buttonText={t("cardDonationText")}
+          buttonText={
+            item.status === "refunded" ? t("refunded") : t("cardDonationText")
+          }
+          refunded={item.status === "refunded"}
         />
       ),
     );


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Change colors and copy when it's a refunded payment

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Make a refund on stripe and see the card on promoters/treasure page
