### PR TITLE
fix: modal header zindex

### DIFF
--- a/src/layouts/LayoutHeader/index.tsx
+++ b/src/layouts/LayoutHeader/index.tsx
@@ -102,6 +102,7 @@ function LayoutHeader({
             display: "flex",
             alignItems: "flex-start",
             justifyContent: "flex-end",
+            zIndex: `${theme.zindex.modal}`,
           },
           content: {
             border: `1px solid ${theme.colors.gray20}`,


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
A Hotfix to fix this:
<img width="1343" alt="Captura de Tela 2022-10-27 às 17 03 02" src="https://user-images.githubusercontent.com/24739860/198398337-897b172a-8e97-4e8a-8da9-3616d092a515.png">
Reported by @luizabrito-pm 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
