### PR TITLE
fix: repeat children to minimum 5

### DIFF
--- a/src/components/moleculars/sliders/SliderCardsEnhanced/index.tsx
+++ b/src/components/moleculars/sliders/SliderCardsEnhanced/index.tsx
@@ -15,6 +15,8 @@ export type Props = {
 
 const SAVE_STATE_PREFIX = "slider-cards-enhanced";
 
+const MINIMUM_SLIDES_TO_LOOP = 5;
+
 export default function SliderCardsEnhanced({
   loop = false,
   currentSlide,
@@ -88,17 +90,33 @@ export default function SliderCardsEnhanced({
     [],
   );
 
+  const renderSlides = () => {
+    let elements = children;
+
+    while (elements.length < MINIMUM_SLIDES_TO_LOOP) {
+      elements = [...elements, ...children];
+    }
+
+    const slides = elements.flat().map(
+      (component: any, idx: number) =>
+        component && (
+          <div className="keen-slider__slide" key={idx.toString()}>
+            {component}
+          </div>
+        ),
+    );
+
+    return slides;
+  };
+
   return (
     <S.NavigationWrapper>
-      <div ref={sliderRef} className="keen-slider">
-        {children.flat().map(
-          (component: any, idx: number) =>
-            component && (
-              <div className="keen-slider__slide" key={idx.toString()}>
-                {component}
-              </div>
-            ),
-        )}
+      <div
+        ref={sliderRef}
+        className="keen-slider"
+        onDrag={(e) => e.preventDefault()}
+      >
+        {renderSlides()}
       </div>
       {loaded && instanceRef.current && (
         <>


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
Keen Slider allows infinite scrolling, but it not deals very well with few slides.
With 2 slides, for example, we have THIS:
![Captura de Tela 2022-12-15 às 12 36 07](https://user-images.githubusercontent.com/24739860/207902548-c910b3b4-1732-4baf-a029-960f912727dc.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
