### PR TITLE
fix: fixed slider size on desktop

### DIFF
--- a/src/components/moleculars/sliders/SliderCardsEnhanced/index.tsx
+++ b/src/components/moleculars/sliders/SliderCardsEnhanced/index.tsx
@@ -11,6 +11,7 @@ export type Props = {
   onCurrentSlideChange: (slide: number) => void;
   children: JSX.Element[];
   saveStateIdentifier?: string;
+  slideWidthOnDesktop?: number;
 };
 
 const SAVE_STATE_PREFIX = "slider-cards-enhanced";
@@ -23,16 +24,26 @@ export default function SliderCardsEnhanced({
   onCurrentSlideChange,
   children,
   saveStateIdentifier,
+  slideWidthOnDesktop = 287,
 }: Props) {
   const [loaded, setLoaded] = useState(false);
-  const { isPad, isMobile } = useBreakpoint();
+  const { isMobile } = useBreakpoint();
   const mounted = useRef(true);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const calculateSlidesPerViewOnDesktop = () => {
+    if (wrapperRef.current) {
+      const wrapperWidth = wrapperRef.current.offsetWidth;
+      return wrapperWidth / slideWidthOnDesktop;
+    }
+
+    return 2.2;
+  };
 
   const getSlidesPerView = () => {
     if (isMobile) return 1.2;
-    if (isPad) return 2.2;
 
-    return 3;
+    return calculateSlidesPerViewOnDesktop();
   };
 
   const saveState = (s: KeenSliderInstance) => {
@@ -110,7 +121,7 @@ export default function SliderCardsEnhanced({
   };
 
   return (
-    <S.NavigationWrapper>
+    <S.NavigationWrapper ref={wrapperRef}>
       <div
         ref={sliderRef}
         className="keen-slider"


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
A fix to THIS:
![Captura de Tela 2022-12-19 às 09 45 46](https://user-images.githubusercontent.com/24739860/208429397-9c5bca76-3fd8-45d8-b248-bfbf129fec2e.png)

We need to use a fixed slide size on desktop (287px for nonProfit cards)

Keen slider doesn't work with slide sizes, the only way to do this is with a dynamic slidesPerView value. Based on sliderWidth / 287px 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
