### PR TITLE
fix: use search param on menu options

### DIFF
--- a/src/config/routes/Navigation/NavigationLink/index.tsx
+++ b/src/config/routes/Navigation/NavigationLink/index.tsx
@@ -14,6 +14,7 @@ export type Props = {
   menuOptions?: {
     path: LocationDescriptor;
     title: string;
+    search?: string;
   }[];
 };
 

--- a/src/config/routes/Navigation/NavigationMenus/FloatingSideMenu/index.tsx
+++ b/src/config/routes/Navigation/NavigationMenus/FloatingSideMenu/index.tsx
@@ -7,6 +7,7 @@ export type Props = {
   menuOptions: {
     path: LocationDescriptor;
     title: string;
+    search?: string;
   }[];
 };
 
@@ -18,7 +19,10 @@ function FloatingSideMenu({
   return (
     <S.Menu visible={visible} onMouseLeave={onMouseLeave}>
       {menuOptions.map((option, index) => (
-        <S.MenuItem key={index.toString(10)} to={option.path}>
+        <S.MenuItem
+          key={index.toString(10)}
+          to={{ pathname: option.path.toString(), search: option.search }}
+        >
           {option.title}
         </S.MenuItem>
       ))}

--- a/src/config/routes/Navigation/index.tsx
+++ b/src/config/routes/Navigation/index.tsx
@@ -85,6 +85,7 @@ function Navigation(): JSX.Element {
           menuOptions={route?.menuOptions?.map((option) => ({
             ...option,
             onClick: () => handleEvent(option.event),
+            search,
           }))}
         />
       ))}


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- We need to use the search param on menu options to retain the integration id throughout dapp use of that session
- 
![image](https://user-images.githubusercontent.com/90937897/219396150-226ee2f6-01ab-477e-b0cf-73fc58afb319.png)


## Does this pull request close any open issues?
- DAPP-676

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
