### PR TITLE
fix: remove integration false from introModal event

### DIFF
--- a/src/hooks/modalHooks/useDonationTicketModal/index.tsx
+++ b/src/hooks/modalHooks/useDonationTicketModal/index.tsx
@@ -56,7 +56,7 @@ export function useDonationTicketModal(
   };
 
   useEffect(() => {
-    if (initialState) showDonationTicketModal();
+    if (initialState && integration) showDonationTicketModal();
   }, []);
 
   return { showDonationTicketModal, hideDonationTicketModal };


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- IntegrationName "false" start appearing again on introModal events
- only show modal if integration is already set


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test if false is going to appear on firebase staging
- Test if that didn't slow modal to appear
