### PR TITLE
fix: update ticket modal to show if the user can donate

### DIFF
--- a/src/pages/donations/CausesPage/index.tsx
+++ b/src/pages/donations/CausesPage/index.tsx
@@ -85,7 +85,7 @@ function CausesPage(): JSX.Element {
     integration,
   );
   const { canDonate } = useCanDonate(integrationId);
-  const { destroyVoucher } = useVoucher();
+  const { destroyVoucher, createVoucher } = useVoucher();
 
   const { isMobile } = useBreakpoint();
 
@@ -108,7 +108,9 @@ function CausesPage(): JSX.Element {
   }, []);
 
   useEffect(() => {
-    if (
+    if (!hasNotSeenDonationModal && hasAvailableDonation) {
+      createVoucher();
+    } else if (
       !hasReceivedTicketToday() ||
       (hasAvailableDonation && hasNotSeenDonationModal)
     ) {


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add logic to allow user to donate if the cooldown has expire

Currently if the cooldown of the user donation resets, the modal to gain tickets does not show and the user cannot click the donate button. With this fix the user can click on the donate button again if he is allowed to donate

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
