### PR TITLE
Add tests to ModalError component

### DIFF
--- a/src/components/moleculars/modals/ModalError/index.test.tsx
+++ b/src/components/moleculars/modals/ModalError/index.test.tsx
@@ -3,7 +3,8 @@ import {
   expectTextNotToBeInTheDocument,
   expectTextToBeInTheDocument,
 } from "config/testUtils/expects";
-import { mockNewLogEventFunction } from "setupTests";
+import {mockNewLogEventFunction, mockZendeskOpenChatFunction} from "setupTests";
+import { screen } from "@testing-library/react";
 import ModalError from ".";
 
 describe("ModalError", () => {
@@ -62,6 +63,30 @@ describe("ModalError", () => {
         eventName,
         eventParams,
       );
+    });
+  });
+
+  describe("when the modal is visible and clicks on button", () => {
+
+    it("open zendesk chat clicking button", () => {
+      renderComponent(
+        <ModalError visible  />,
+      );
+      const button = screen.getByRole("button")
+      button.click()
+      expect(mockZendeskOpenChatFunction).toHaveBeenCalled()
+
+
+    });
+  });
+  describe("when warning is passed", () => {
+
+    it("should show warningIcon", () => {
+      renderComponent(
+          <ModalError visible warning />,
+      );
+        const icon = screen.getByRole("img")
+        expect(icon).toHaveAttribute("src", "warning-icon.svg")
     });
   });
 });

--- a/src/components/moleculars/modals/ModalError/index.test.tsx
+++ b/src/components/moleculars/modals/ModalError/index.test.tsx
@@ -69,10 +69,9 @@ describe("ModalError", () => {
   describe("when the modal is visible and clicks on button", () => {
     it("open zendesk chat clicking button", () => {
       renderComponent(
-        <ModalError visible  />,
+        <ModalError visible />,
       );
-      const button = screen.getByRole("button")
-      button.click()
+      clickOn("Access user support");
       expect(mockZendeskOpenChatFunction).toHaveBeenCalled()
     });
   });

--- a/src/components/moleculars/modals/ModalError/index.test.tsx
+++ b/src/components/moleculars/modals/ModalError/index.test.tsx
@@ -45,7 +45,6 @@ describe("ModalError", () => {
         />,
       );
       clickOn("button");
-
       expect(mockFunction).toHaveBeenCalled();
     });
   });
@@ -72,7 +71,7 @@ describe("ModalError", () => {
         <ModalError visible />,
       );
       clickOn("Access user support");
-      expect(mockZendeskOpenChatFunction).toHaveBeenCalled()
+      expect(mockZendeskOpenChatFunction).toHaveBeenCalled();
     });
   });
 

--- a/src/components/moleculars/modals/ModalError/index.test.tsx
+++ b/src/components/moleculars/modals/ModalError/index.test.tsx
@@ -67,7 +67,6 @@ describe("ModalError", () => {
   });
 
   describe("when the modal is visible and clicks on button", () => {
-
     it("open zendesk chat clicking button", () => {
       renderComponent(
         <ModalError visible  />,
@@ -75,12 +74,10 @@ describe("ModalError", () => {
       const button = screen.getByRole("button")
       button.click()
       expect(mockZendeskOpenChatFunction).toHaveBeenCalled()
-
-
     });
   });
-  describe("when warning is passed", () => {
 
+  describe("when warning is passed", () => {
     it("should show warningIcon", () => {
       renderComponent(
           <ModalError visible warning />,

--- a/src/components/moleculars/modals/ModalError/index.tsx
+++ b/src/components/moleculars/modals/ModalError/index.tsx
@@ -22,6 +22,7 @@ export type Props = {
   eventName?: string;
   eventParams?: Record<string, any>;
 };
+
 function ModalError({
   visible = false,
   title = null,

--- a/src/components/moleculars/modals/ModalError/styles.ts
+++ b/src/components/moleculars/modals/ModalError/styles.ts
@@ -27,11 +27,6 @@ export const Body = styled.h4`
   color: ${({ theme }) => theme.colors.neutral[500]};
 `;
 
-export const RowsModalRow = styled.div`
-  margin-bottom: ${({ theme }) => theme.spacing(32)};
-  display: flex;
-`;
-
 export const SupportButton = styled(Button)`
   border: 1px solid ${({ theme }) => theme.colors.brand.primary[300]};
   background-color: ${({ theme }) => theme.colors.neutral10};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -8,6 +8,7 @@ export const mockLogEventFunction = jest.fn();
 export const mockNewLogEventFunction = jest.fn();
 export const mockLogPageViewFunction = jest.fn();
 export const mockLocationReload = jest.fn();
+export const mockZendeskOpenChatFunction = jest.fn();
 
 export function setupMocks() {
   jest.mock("hooks/useNavigation", () => ({
@@ -28,6 +29,10 @@ export function setupMocks() {
     logPageView: mockLogPageViewFunction,
     newLogEvent: mockNewLogEventFunction,
   }));
+  jest.mock("config/zendesk/features", () => ({
+    __esModule: true,
+    ZendeskOpenChat: mockZendeskOpenChatFunction,
+  }))
   delete (window as any).location;
   (window as any).location = { reload: mockLocationReload };
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -32,7 +32,7 @@ export function setupMocks() {
   jest.mock("config/zendesk/features", () => ({
     __esModule: true,
     ZendeskOpenChat: mockZendeskOpenChatFunction,
-  }))
+  }));
   delete (window as any).location;
   (window as any).location = { reload: mockLocationReload };
 }


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Add test to the ModalError component

## Does this pull request close any open issues?

- closes (https://github.com/RibonDAO/interface/issues/461)

## Type of change

Please delete options that are not relevant.

- [X] Tests

![image](https://user-images.githubusercontent.com/77304049/223493355-59f28f4d-2f7b-45a7-a13a-1634dddbfe2b.png)

Only function with no coverage is the default void function created if onClose is not passed on props, hope this is acceptable 😅
![image](https://user-images.githubusercontent.com/77304049/223493462-6a3d0c0a-0f35-4113-9b28-9bc30597969c.png)

