### PR TITLE
fix: autocomplete off on input autocomplete

### DIFF
--- a/src/components/atomics/inputs/InputAutoComplete/index.test.tsx
+++ b/src/components/atomics/inputs/InputAutoComplete/index.test.tsx
@@ -58,11 +58,11 @@ describe("InputAutoComplete", () => {
   });
 
   it("should always have autocomplete off", () => {
-    expect(input).toHaveAttribute("autocomplete", "off");
+    expect(input).toHaveAttribute("autocomplete", "nope");
   });
 
   it("always should have required turned on if given", () => {
-    expect(input).toHaveAttribute("autocomplete", "off");
+    expect(input).toHaveAttribute("autocomplete", "nope");
   });
 
   it("should not show more than 4 suggestions", () => {

--- a/src/components/atomics/inputs/InputAutoComplete/index.tsx
+++ b/src/components/atomics/inputs/InputAutoComplete/index.tsx
@@ -66,7 +66,7 @@ function InputAutoComplete({
         aria-label={placeholder}
         name={name}
         required={required}
-        autoComplete="off"
+        autoComplete="nope"
         textColor={textColor}
         borderColor={borderColor}
         {...props}


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- autocomplete off on input autocomplete
- the "off" was not working, but with "nope" it is

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
