### PR TITLE
fix: update causes context to set active cause as all when refetching…

### DIFF
--- a/src/contexts/causesContext/index.tsx
+++ b/src/contexts/causesContext/index.tsx
@@ -38,9 +38,9 @@ function CausesProvider({ children }: any) {
   useEffect(() => {
     if (!isLoading) {
       setActiveCauses(causesFilter());
-      setCurrentCauseId(activeCauses[0]?.id);
+      setCurrentCauseId(causeWasNotSelectedByModal);
     }
-  }, [causes, isLoading]);
+  }, [JSON.stringify(causes), isLoading]);
 
   const causesObject: ICausesContext = useMemo(
     () => ({


### PR DESCRIPTION
… causes

<!-- Delete any of those topics if they don't fit -->

# Description

- FIx causes context refetch default active cause set

We were setting the first cause as the active cause when refetching. We should instead set all causes as the active since we were restricting the user possibility to see all causes when refetching
# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Put here all the things need to test this PR and verify your changes, also list any relevant details for tests (eg: have a wallet)

- Test A
