### PR TITLE
fix: add search to accordion menu

### DIFF
--- a/src/config/routes/Navigation/NavigationMenus/AccordionMenu/index.tsx
+++ b/src/config/routes/Navigation/NavigationMenus/AccordionMenu/index.tsx
@@ -9,6 +9,7 @@ export type Props = {
   menuOptions: {
     path: LocationDescriptor;
     title: string;
+    search?: string;
   }[];
 };
 
@@ -65,7 +66,7 @@ function AccordionMenu({ menuOptions }: Props): JSX.Element {
           <S.MenuItem
             $active={isButtonActive(option.path)}
             key={index.toString(10)}
-            to={option.path}
+            to={{ pathname: option.path.toString(), search: option.search }}
           >
             {option.title}
           </S.MenuItem>


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description

- Fix accordion menu search maintaining param

The search param was being lost if the user was on mobile and going to the direct donation page
# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes [#001]()

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

Enter in an integration flow, go to the direct contribution page in mobile mode and check if the search is maintained
