### PR TITLE
feat: adds zendesk web widget chat for en

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -131,28 +131,48 @@
       })(window, document, "https://static.hotjar.com/c/hotjar-", ".js?sv=");
     </script>
 
-    <script type='text/javascript'>
-      window.smartlook||(function(d) {
-        var o=smartlook=function(){ o.api.push(arguments)},h=d.getElementsByTagName('head')[0];
-        var c=d.createElement('script');o.api=new Array();c.async=true;c.type='text/javascript';
-        c.charset='utf-8';c.src='https://web-sdk.smartlook.com/recorder.js';h.appendChild(c);
+    <script type="text/javascript">
+      window.smartlook ||
+        (function (d) {
+          var o = (smartlook = function () {
+              o.api.push(arguments);
+            }),
+            h = d.getElementsByTagName("head")[0];
+          var c = d.createElement("script");
+          o.api = new Array();
+          c.async = true;
+          c.type = "text/javascript";
+          c.charset = "utf-8";
+          c.src = "https://web-sdk.smartlook.com/recorder.js";
+          h.appendChild(c);
         })(document);
-        smartlook('init', '55dca9c32feaa4137d9b40971d3bc334ac1b3499', { region: 'eu' });
+      smartlook("init", "55dca9c32feaa4137d9b40971d3bc334ac1b3499", {
+        region: "eu",
+      });
     </script>
-    <title>Ribon</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
 
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
 
+<title>Ribon</title>
+</head>
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
+    This HTML file is a template.
+    If you open it directly in the browser, you will see an empty page.
+    
+    You can add webfonts, meta tags, or analytics to this file.
+    The build step will place the bundled scripts into the <body> tag.
+      
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <!-- ribonapp Zendesk Widget script (Zendesk support chat) -->
+    <!-- This is supposed to be on the body so as to not affect the site's performance -->
+    <script
+      id="ze-snippet"
+      src="https://static.zdassets.com/ekr/snippet.js?key=efe9ba42-3eee-48a3-aa79-b573e297fef4"
+    ></script>
+    <!-- End of ribonapp Zendesk Widget script -->
   </body>
 </html>

--- a/src/components/moleculars/banners/UserSupportBanner/index.test.tsx
+++ b/src/components/moleculars/banners/UserSupportBanner/index.test.tsx
@@ -3,8 +3,16 @@ import {
   expectLogEventToHaveBeenCalledWith,
   expectTextToBeInTheDocument,
 } from "config/testUtils/expects";
+import { setLocalStorageItem } from "lib/localStorage";
 import { screen } from "@testing-library/react";
+import startSupportChat from "services/support";
+import { I18NEXTLNG } from "lib/currentLanguage";
 import UserSupportBanner from ".";
+
+jest.mock("services/support", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 
 describe("UserSupportBanner", () => {
   window.open = jest.fn();
@@ -16,14 +24,19 @@ describe("UserSupportBanner", () => {
     expectTextToBeInTheDocument("Questions, ideias, refunds. We’re here!");
   });
 
-  describe("when the banner is clicked", () => {
+  describe("when the banner is clicked in portuguese", () => {
     beforeEach(() => {
+      Object.defineProperty(window, "navigator", {
+        value: { language: "pt-BR" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "pt-BR");
+      
       renderComponent(<UserSupportBanner from="test" />);
       const banner = screen.getByTestId("banner");
-
+      
       clickOn(banner);
     });
-
+    
     it("opens the support link", () => {
       expect(window.open).toHaveBeenCalled();
     });
@@ -32,4 +45,23 @@ describe("UserSupportBanner", () => {
       expectLogEventToHaveBeenCalledWith("supportBtn_click", { from: "test" });
     });
   });
+
+  describe("when the banner is clicked in English", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "navigator", {
+        value: { language: "en" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "en");
+  
+      renderComponent(<UserSupportBanner from="test" />);
+      const banner = screen.getByTestId("banner");
+  
+      clickOn(banner);
+    });
+  
+    it("starts the support chat", () => {
+      expect(startSupportChat).toHaveBeenCalled();
+    });
+  });
+  
 });

--- a/src/components/moleculars/banners/UserSupportBanner/index.test.tsx
+++ b/src/components/moleculars/banners/UserSupportBanner/index.test.tsx
@@ -30,13 +30,13 @@ describe("UserSupportBanner", () => {
         value: { language: "pt-BR" },
       });
       setLocalStorageItem(I18NEXTLNG, "pt-BR");
-      
+
       renderComponent(<UserSupportBanner from="test" />);
       const banner = screen.getByTestId("banner");
-      
+
       clickOn(banner);
     });
-    
+
     it("opens the support link", () => {
       expect(window.open).toHaveBeenCalled();
     });
@@ -52,16 +52,15 @@ describe("UserSupportBanner", () => {
         value: { language: "en" },
       });
       setLocalStorageItem(I18NEXTLNG, "en");
-  
+
       renderComponent(<UserSupportBanner from="test" />);
       const banner = screen.getByTestId("banner");
-  
+
       clickOn(banner);
     });
-  
+
     it("starts the support chat", () => {
       expect(startSupportChat).toHaveBeenCalled();
     });
   });
-  
 });

--- a/src/components/moleculars/banners/UserSupportBanner/index.tsx
+++ b/src/components/moleculars/banners/UserSupportBanner/index.tsx
@@ -1,7 +1,10 @@
+import { Languages } from "@ribon.io/shared/types";
 import { theme } from "@ribon.io/shared/styles";
 import Banner from "components/moleculars/cards/Banner";
+import { useLanguage } from "hooks/useLanguage";
 import { logEvent } from "lib/events";
 import { useTranslation } from "react-i18next";
+import startSupportChat from "services/support";
 import CardBackground from "./assets/background.svg";
 
 type Props = {
@@ -11,12 +14,17 @@ function UserSupportBanner({ from }: Props): JSX.Element {
   const { t } = useTranslation("translation", {
     keyPrefix: "layouts.userSupportBanner",
   });
+  const { currentLang } = useLanguage();
 
   const handleClick = () => {
     logEvent("supportBtn_click", {
       from,
     });
-    window.open(t("userSupportLink"), "_blank");
+    if (currentLang === Languages.PT) {
+      window.open(t("userSupportLink"), "_blank");
+    } else {
+      startSupportChat();
+    }
   };
 
   return (

--- a/src/components/moleculars/modals/ModalIcon/index.test.tsx
+++ b/src/components/moleculars/modals/ModalIcon/index.test.tsx
@@ -6,7 +6,15 @@ import {
 } from "config/testUtils/expects";
 import { screen } from "@testing-library/react";
 import { mockNewLogEventFunction } from "setupTests";
+import { setLocalStorageItem } from "lib/localStorage";
+import { I18NEXTLNG } from "lib/currentLanguage";
+import startSupportChat from "services/support";
 import ModalIcon from ".";
+
+jest.mock("services/support", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 
 describe("ModalIcon", () => {
   it("should render without error", () => {
@@ -104,6 +112,44 @@ describe("ModalIcon", () => {
         eventName,
         eventParams,
       );
+    });
+  });
+
+  describe("when the support button is clicked in portuguese", () => {
+    beforeEach(() => {
+      window.open = jest.fn();
+
+      Object.defineProperty(window, "navigator", {
+        value: { language: "pt-BR" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "pt-BR");
+
+      renderComponent(<ModalIcon title="text" visible supportButton />);
+      const button = screen.getByText("Access user support");
+
+      clickOn(button);
+    });
+
+    it("opens the support link", () => {
+      expect(window.open).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the support button is clicked in English", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "navigator", {
+        value: { language: "en" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "en");
+
+      renderComponent(<ModalIcon title="text" visible supportButton />);
+      const button = screen.getByText("Access user support");
+
+      clickOn(button);
+    });
+
+    it("starts the support chat", () => {
+      expect(startSupportChat).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/moleculars/modals/ModalIcon/index.tsx
+++ b/src/components/moleculars/modals/ModalIcon/index.tsx
@@ -4,6 +4,9 @@ import Button, { ButtonProps } from "components/atomics/buttons/Button";
 import theme from "styles/theme";
 import { newLogEvent } from "lib/events";
 import { useTranslation } from "react-i18next";
+import { useLanguage } from "hooks/useLanguage";
+import { Languages } from "@ribon.io/shared/types";
+import startSupportChat from "services/support";
 import * as S from "./styles";
 import { defaultCustomStyles } from "../defaultCustomStyles";
 
@@ -49,7 +52,7 @@ function ModalIcon({
   eventParams,
 }: Props): JSX.Element {
   const [logged, SetLogged] = useState(false);
-
+  const { currentLang } = useLanguage();
   const { t } = useTranslation("translation", {
     keyPrefix: "donations.causesPage.modalForm",
   });
@@ -67,8 +70,11 @@ function ModalIcon({
   }
 
   const handleSupportButtonClick = () => {
-    window.open(t("userSupportLink"), "_blank");
-    newLogEvent("click", "supportBtn", { from: "error_modal" });
+    if (currentLang === Languages.PT) {
+      window.open(t("userSupportLink"), "_blank");
+    } else {
+      startSupportChat();
+    }
   };
 
   return (

--- a/src/config/zendesk/index.tsx
+++ b/src/config/zendesk/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import { useCurrentUser } from "contexts/currentUserContext";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import ZendeskApp, { ZendeskAPI } from "react-zendesk";
 import theme from "styles/theme";
@@ -14,11 +15,23 @@ function Zendesk(): JSX.Element {
     },
   };
   const { i18n } = useTranslation();
+  const { currentUser } = useCurrentUser();
   const [currentLang] = useState(i18n.language);
   const ZENDESK_KEY = process.env.REACT_APP_ZENDESK_KEY ?? "";
 
   const loadZendeskApi = () => {
-    ZendeskAPI("messenger:set", "locale", currentLang);
+    ZendeskAPI("webWidget", "identify", {
+      id: currentUser?.id,
+      email: currentUser?.email,
+    });
+    ZendeskAPI("webWidget", "prefill", {
+      email: { value: currentUser?.email, readOnly: false },
+    });
+    ZendeskAPI("webWidget", "chat:addTags", [
+      `currentUser_id:${currentUser?.id}`,
+    ]);
+    ZendeskAPI("webWidget", "show");
+    ZendeskAPI("webWidget", "setLocale", currentLang);
   };
 
   return (

--- a/src/layouts/LayoutHeader/UserSupportItem/index.test.tsx
+++ b/src/layouts/LayoutHeader/UserSupportItem/index.test.tsx
@@ -1,12 +1,57 @@
-import React from "react";
-
-import { renderComponent } from "config/testUtils";
+import { clickOn, renderComponent } from "config/testUtils";
 import { expectTextToBeInTheDocument } from "config/testUtils/expects";
+import { setLocalStorageItem } from "lib/localStorage";
+import { I18NEXTLNG } from "lib/currentLanguage";
+import { screen } from "@testing-library/react";
+import startSupportChat from "services/support";
 import UserSupportItem from ".";
+
+jest.mock("services/support", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 
 describe("UserSupportItem component", () => {
   it("renders the correct text", () => {
     renderComponent(<UserSupportItem />);
     expectTextToBeInTheDocument("User Support");
+  });
+
+  describe("when the support button is clicked in portuguese", () => {
+    beforeEach(() => {
+      window.open = jest.fn();
+
+      Object.defineProperty(window, "navigator", {
+        value: { language: "pt-BR" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "pt-BR");
+
+      renderComponent(<UserSupportItem />);
+      const button = screen.getByText("User Support");
+
+      clickOn(button);
+    });
+
+    it("opens the support link", () => {
+      expect(window.open).toHaveBeenCalled();
+    });
+  });
+
+  describe("when the support button is clicked in English", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "navigator", {
+        value: { language: "en" },
+      });
+      setLocalStorageItem(I18NEXTLNG, "en");
+
+      renderComponent(<UserSupportItem />);
+      const button = screen.getByText("User Support");
+
+      clickOn(button);
+    });
+
+    it("starts the support chat", () => {
+      expect(startSupportChat).toHaveBeenCalled();
+    });
   });
 });

--- a/src/layouts/LayoutHeader/UserSupportItem/index.tsx
+++ b/src/layouts/LayoutHeader/UserSupportItem/index.tsx
@@ -25,11 +25,11 @@ function UserSupportItem(): JSX.Element {
   };
 
   return (
-    <S.Container>
+    <S.Container onClick={handleClick}>
       <CardIconText
         text={t("userSupportText")}
         icon={supportIcon}
-        rightComponent={<S.GoButton src={ArrowRight} onClick={handleClick} />}
+        rightComponent={<S.GoButton src={ArrowRight} />}
       />
     </S.Container>
   );

--- a/src/layouts/LayoutHeader/UserSupportItem/index.tsx
+++ b/src/layouts/LayoutHeader/UserSupportItem/index.tsx
@@ -3,19 +3,25 @@ import supportIcon from "assets/icons/support-icon.svg";
 import CardIconText from "components/moleculars/cards/CardIconText";
 import { useTranslation } from "react-i18next";
 import ArrowRight from "assets/icons/arrow-right-blue-icon.svg";
-import { logEvent, newLogEvent } from "lib/events";
+import { logEvent } from "lib/events";
+import { useLanguage } from "hooks/useLanguage";
+import { Languages } from "@ribon.io/shared/types";
+import startSupportChat from "services/support";
 import * as S from "./styles";
 
 function UserSupportItem(): JSX.Element {
   const { t } = useTranslation("translation", {
     keyPrefix: "layouts.layoutHeader.userSupportItem",
   });
+  const { currentLang } = useLanguage();
 
   const handleClick = () => {
     logEvent("UserSupportBtn_click");
-    window.open(t("userSupportLink"), "_blank");
-
-    newLogEvent("click", "userSupportBtn_click", { from: "config_page" });
+    if (currentLang === Languages.PT) {
+      window.open(t("userSupportLink"), "_blank");
+    } else {
+      startSupportChat();
+    }
   };
 
   return (

--- a/src/layouts/LayoutHeader/UserSupportItem/index.tsx
+++ b/src/layouts/LayoutHeader/UserSupportItem/index.tsx
@@ -29,7 +29,7 @@ function UserSupportItem(): JSX.Element {
       <CardIconText
         text={t("userSupportText")}
         icon={supportIcon}
-        rightComponent={<S.GoButton src={ArrowRight} />}
+        rightComponent={<S.GoButton src={ArrowRight} onClick={handleClick} />}
       />
     </S.Container>
   );

--- a/src/services/support/index.ts
+++ b/src/services/support/index.ts
@@ -1,0 +1,7 @@
+import startZendeskSupportChat from "./zendesk";
+
+function startSupportChat() {
+  startZendeskSupportChat();
+}
+
+export default startSupportChat;

--- a/src/services/support/zendesk/index.ts
+++ b/src/services/support/zendesk/index.ts
@@ -1,0 +1,7 @@
+import { ZendeskAPI } from "react-zendesk";
+
+function startZendeskSupportChat() {
+  ZendeskAPI("messenger", "open");
+}
+
+export default startZendeskSupportChat;


### PR DESCRIPTION
# Description

- Adds the web widget option on web for non portuguese speakers

## Does this pull request close any open issues?

- [#prod3-170](https://ribon.atlassian.net/browse/PROD3-170?atlOrigin=eyJpIjoiYmIzNGNmNTk4MTQ5NGNiNmEwMzJiZmFlMmQzYjc4NzkiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

## How to test

- change language to english and try click on the support banner (check if the chat appears)