### PR TITLE
feat: remove currency button during xmas campaign

### DIFF
--- a/src/pages/promoters/CheckoutPage/Components/Header/index.test.tsx
+++ b/src/pages/promoters/CheckoutPage/Components/Header/index.test.tsx
@@ -1,22 +1,21 @@
-import { clickOn, renderComponent } from "config/testUtils";
-import { expectTextToBeInTheDocument } from "config/testUtils/expects";
+import { /* clickOn, */ renderComponent } from "config/testUtils";
+// import { expectTextToBeInTheDocument } from "config/testUtils/expects";
 import Header from ".";
 
 describe("Header", () => {
   it("should render without error", () => {
     renderComponent(<Header />);
 
-    expectTextToBeInTheDocument("Change currency");
+    // expectTextToBeInTheDocument("Change currency");
   });
 
   describe("when the button currency is clicked", () => {
-    beforeEach(() => {
-      renderComponent(<Header />);
-      clickOn("Change currency");
-    });
-
-    it("when the currecy is choosed", () => {
-      expectTextToBeInTheDocument("BRL");
-    });
+    // beforeEach(() => {
+    //   renderComponent(<Header />);
+    //   clickOn("Change currency");
+    // });
+    // it("when the currecy is choosed", () => {
+    //   expectTextToBeInTheDocument("BRL");
+    // });
   });
 });

--- a/src/pages/promoters/CheckoutPage/Components/Header/index.tsx
+++ b/src/pages/promoters/CheckoutPage/Components/Header/index.tsx
@@ -1,14 +1,14 @@
 import ArrowLeftGreen from "assets/icons/arrow-left-dark-green.svg";
-import CurrencyExchange from "assets/icons/currency-exchange-icon.svg";
-import usePaymentParams from "hooks/usePaymentParams";
-import { useLocationSearch } from "hooks/useLocationSearch";
+// import CurrencyExchange from "assets/icons/currency-exchange-icon.svg";
+// import usePaymentParams from "hooks/usePaymentParams";
+// import { useLocationSearch } from "hooks/useLocationSearch";
 import { useTranslation } from "react-i18next";
-import { useExperiment } from "@growthbook/growthbook-react";
-import { useModal } from "hooks/modalHooks/useModal";
-import { MODAL_TYPES } from "contexts/modalContext/helpers";
-import { Currencies } from "@ribon.io/shared/types";
+// import { useExperiment } from "@growthbook/growthbook-react";
+// import { useModal } from "hooks/modalHooks/useModal";
+// import { MODAL_TYPES } from "contexts/modalContext/helpers";
+// import { Currencies } from "@ribon.io/shared/types";
 import useNavigation from "hooks/useNavigation";
-import ButtonSelectorTemplate from "../ButtonSelectorTemplate";
+// import ButtonSelectorTemplate from "../ButtonSelectorTemplate";
 import * as S from "./styles";
 
 export default function Header() {
@@ -16,63 +16,63 @@ export default function Header() {
     keyPrefix: "promoters.checkoutPage",
   });
 
-  const variation = useExperiment({
-    key: "payment-form",
-    variations: [false, true],
-  });
+  // const variation = useExperiment({
+  //   key: "payment-form",
+  //   variations: [false, true],
+  // });
 
-  const { currency, target } = usePaymentParams();
-  const { updateLocationSearch } = useLocationSearch();
+  // const { currency, target } = usePaymentParams();
+  // const { updateLocationSearch } = useLocationSearch();
   const { navigateBack } = useNavigation();
 
-  const handleCurrencyChange = (currencyItem: Currencies) => {
-    updateLocationSearch("currency", currencyItem);
-  };
+  // const handleCurrencyChange = (currencyItem: Currencies) => {
+  //   updateLocationSearch("currency", currencyItem);
+  // };
 
-  const buttonCurrencyItems = Object.values(Currencies)
-    .map((currencyItem) => ({
-      label: currencyItem,
-      onClick: () => handleCurrencyChange(currencyItem),
-    }))
-    .filter((currencyItem) => currencyItem.label !== Currencies.USDC);
+  // const buttonCurrencyItems = Object.values(Currencies)
+  //   .map((currencyItem) => ({
+  //     label: currencyItem,
+  //     onClick: () => handleCurrencyChange(currencyItem),
+  //   }))
+  //   .filter((currencyItem) => currencyItem.label !== Currencies.USDC);
 
-  const filteredCurrencyItems = () => {
-    if (target === "non_profit") {
-      return buttonCurrencyItems.filter(
-        (item) => item.label !== Currencies.USDC,
-      );
-    }
-    return buttonCurrencyItems;
-  };
+  // const filteredCurrencyItems = () => {
+  //   if (target === "non_profit") {
+  //     return buttonCurrencyItems.filter(
+  //       (item) => item.label !== Currencies.USDC,
+  //     );
+  //   }
+  //   return buttonCurrencyItems;
+  // };
 
-  const currencyModalProps = {
-    title: t("selectCurrency"),
-    children: (
-      <ButtonSelectorTemplate
-        items={filteredCurrencyItems()}
-        current={Object.values(Currencies).indexOf(currency as Currencies)}
-      />
-    ),
-  };
+  // const currencyModalProps = {
+  //   title: t("selectCurrency"),
+  //   children: (
+  //     <ButtonSelectorTemplate
+  //       items={filteredCurrencyItems()}
+  //       current={Object.values(Currencies).indexOf(currency as Currencies)}
+  //     />
+  //   ),
+  // };
 
-  const { show: showCurrencyModal } = useModal({
-    type: MODAL_TYPES.MODAL_DIALOG,
-    props: currencyModalProps,
-  });
+  // const { show: showCurrencyModal } = useModal({
+  //   type: MODAL_TYPES.MODAL_DIALOG,
+  //   props: currencyModalProps,
+  // });
 
   return (
     <S.Header>
       <S.BackButton onClick={navigateBack}>
         <img src={ArrowLeftGreen} alt={t("back")} />
       </S.BackButton>
-      {!variation.value ? (
+      {/* {!variation.value ? (
         <S.ChangeCurrencyButton onClick={() => showCurrencyModal()}>
           <img src={CurrencyExchange} alt={t("changeCurrency")} />
           <p>{t("changeCurrency")}</p>
         </S.ChangeCurrencyButton>
       ) : (
         <div />
-      )}
+      )} */}
     </S.Header>
   );
 }

--- a/src/pages/promoters/CheckoutPage/index.test.tsx
+++ b/src/pages/promoters/CheckoutPage/index.test.tsx
@@ -1,6 +1,6 @@
 import { renderComponent } from "config/testUtils";
 import {
-  expectTextToBeInTheDocument,
+  // expectTextToBeInTheDocument,
   expectLogEventToHaveBeenCalledWith,
 } from "config/testUtils/expects";
 import CheckoutPage from ".";
@@ -9,7 +9,7 @@ describe("CheckoutPage", () => {
   it("should render without error", () => {
     renderComponent(<CheckoutPage />);
 
-    expectTextToBeInTheDocument("Change currency");
+    // expectTextToBeInTheDocument("Change currency");
   });
 
   it("logs the page view event", () => {


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
Remove change currency button during xmas campaign, because we have so many offers in the modal, causing a child elements overflow.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests
