### PR TITLE
feat: redirect page

### DIFF
--- a/src/config/routes/index.tsx
+++ b/src/config/routes/index.tsx
@@ -42,6 +42,7 @@ import ValidateExtraTicket from "pages/auth/ValidateExtraTicketPage";
 import InsertEmailAccountPage from "pages/donations/auth/InsertEmailAccountPage";
 import ExtraTicketPage from "pages/auth/ExtraTicketPage";
 import SignInExtraTicketPage from "pages/auth/SignInExtraTicketPage";
+import RedirectPage from "pages/campaigns/redirectPage";
 import ReceiveExtraTicketPage from "pages/auth/ReceiveExtraTicketPage";
 import SignInByMagicLinkPage from "pages/donations/auth/SignInByMagicLinkPage";
 import DonationSignInPage from "pages/donations/auth/SignInPage";
@@ -54,7 +55,6 @@ import NavigationBackHeader from "./Navigation/NavigationBackHeader";
 
 function RoutesComponent(): JSX.Element {
   const location = useLocation();
-
   useEffect(() => {
     const urlName = location.pathname.replace(/\/\d+/, "");
     const { search, state } = location;
@@ -90,6 +90,12 @@ function RoutesComponent(): JSX.Element {
         <Suspense fallback={<div />}>
           <NavigationBackHeader />
           <SentMagicLinkEmailPage />
+        </Suspense>
+      </Route>
+
+      <Route path="/redirect">
+        <Suspense fallback={<div />}>
+          <RedirectPage />
         </Suspense>
       </Route>
 

--- a/src/pages/campaigns/redirectPage/index.tsx
+++ b/src/pages/campaigns/redirectPage/index.tsx
@@ -39,7 +39,9 @@ export default function RedirectPage() {
 
   function redirectUrlWithUTM() {
     const url = new URL(
-      decodeURIComponent(isValidUrl(redirectUrl) ? redirectUrl : DAPP_URL),
+      decodeURIComponent(
+        isValidUrl(decodeURIComponent(redirectUrl)) ? redirectUrl : DAPP_URL,
+      ),
     );
     url.searchParams.append("utm_source", utmParams.utmSource);
     url.searchParams.append("utm_medium", utmParams.utmMedium);

--- a/src/pages/campaigns/redirectPage/index.tsx
+++ b/src/pages/campaigns/redirectPage/index.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import useNavigation from "hooks/useNavigation";
+import extractUrlValue from "lib/extractUrlValue";
+import { logEvent } from "lib/events";
+import { getUTMFromLocationSearch } from "lib/getUTMFromLocationSearch";
+import { DAPP_URL } from "utils/constants";
+import { isValidUrl } from "lib/validators";
+
+export default function RedirectPage() {
+  const { history } = useNavigation();
+  const utmParams = getUTMFromLocationSearch(history.location.search);
+  const redirectUrl =
+    extractUrlValue("redirect_url", history.location.search) || "";
+  const event = extractUrlValue("event", history.location.search);
+
+  const [ip, setIp] = useState("");
+  const { userAgent } = navigator;
+
+  const getClientIP = async () => {
+    const response = await fetch("https://api.ipify.org?format=json");
+    const data = await response.json();
+    setIp(data.ip);
+  };
+
+  const parsedEventParams = () => ({
+    utmSource: utmParams.utmSource,
+    utmMedium: utmParams.utmMedium,
+    utmCampaign: utmParams.utmCampaign,
+    redirectUrl,
+    clientIp: ip,
+    userAgent,
+  });
+
+  const handleEvent = () => {
+    if (event) {
+      logEvent(event, parsedEventParams());
+    }
+  };
+
+  function redirectUrlWithUTM() {
+    const url = new URL(
+      decodeURIComponent(isValidUrl(redirectUrl) ? redirectUrl : DAPP_URL),
+    );
+    url.searchParams.append("utm_source", utmParams.utmSource);
+    url.searchParams.append("utm_medium", utmParams.utmMedium);
+    url.searchParams.append("utm_campaign", utmParams.utmCampaign);
+    return url.href;
+  }
+
+  useEffect(() => {
+    getClientIP();
+  }, []);
+
+  useEffect(() => {
+    if (redirectUrl && ip) {
+      handleEvent();
+      window.location.href =
+        redirectUrlWithUTM() || decodeURIComponent(redirectUrl);
+    }
+  }, [redirectUrl, ip]);
+
+  return <div />;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -41,3 +41,5 @@ export const INTEGRATION_AUTH_ID =
 
 export const USER_SUPPORT_LINK =
   "https://api.whatsapp.com/send/?phone=554896605461&text=Oii+Ribon%2C+vamos+conversar%3F+&type=phone_number&app_absent=0";
+
+export const DAPP_URL = "https://dapp.ribon.io/";


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->

# Description
- A simple URL redirect page, that collects some user data and registers an event.

Functionalities:
 - UTM passthrough
 - Fallback to dapp if url isn't invalid
 - Event logging customizable via search params, registering UTMs, user IP and user agent

NOTE: I did some manual tests to ensure that everything is working, but didn't found a proper way to write unit tests on it. If someone had any ideia I'll be glad to implement

URL Builder for someone who needs it: https://ribon-url-builder.netlify.app/

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Dangerous changes
- [ ] Chore (change that does not effect how the code works, eg: change color)
- [ ] Tests

